### PR TITLE
Altera cor do link Easy Pallet na hero para azul

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -365,7 +365,7 @@ const socialIcons: Record<string, string> = {
   }
 
   .hero-content :global(a) {
-    color: #e00000;
+    color: #2563eb;
     text-decoration: underline;
   }
 


### PR DESCRIPTION
Muda a cor do link na seção hero de vermelho (#e00000) para azul (#2563eb).

https://claude.ai/code/session_017nfNzX4JLmtJ9Zq2a8UUas

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely visual change limited to the hero section link styling; no logic, data, or security impact.
> 
> **Overview**
> Updates the hero section link styling on `src/pages/index.astro`, changing the anchor color from red (`#e00000`) to blue (`#2563eb`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42e094b7d530d69cc8c575653e529f89b7f0ba83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->