### PR TITLE
Corrige aspas duplicadas no post e reverte cor do link Easy Pallet

### DIFF
--- a/site/content/posts/pt/2025-03-25-o-poder-realista-do-pensamento-positivo.md
+++ b/site/content/posts/pt/2025-03-25-o-poder-realista-do-pensamento-positivo.md
@@ -10,8 +10,8 @@ translatedPosts:
   es: 'el-poder-realista-del-pensamiento-positivo-es'
 ---
 
-> “O que você pensa determina a qualidade da sua mente.
-> **Sua alma assume a cor dos seus pensamentos.**”
+> O que você pensa determina a qualidade da sua mente.
+> **Sua alma assume a cor dos seus pensamentos.**
 > — Marco Aurélio (Meditações 5.16)
 
 Em uma fase da minha vida, adotei um pensamento extremamente positivo — e os resultados foram excelentes em várias áreas.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -365,7 +365,7 @@ const socialIcons: Record<string, string> = {
   }
 
   .hero-content :global(a) {
-    color: #2563eb;
+    color: #e00000;
     text-decoration: underline;
   }
 


### PR DESCRIPTION
- Remove aspas explícitas do blockquote em "O poder realista do pensamento
  positivo" (PT), já que o Tailwind prose adiciona aspas curvas automaticamente
- Reverte cor do link Easy Pallet na hero de azul (#2563eb) para vermelho
  (#e00000)